### PR TITLE
Shorten package description

### DIFF
--- a/standoff-mode-pkg.el
+++ b/standoff-mode-pkg.el
@@ -1,3 +1,3 @@
 (define-package "standoff-mode"
   "0.2.2"
-  "Create stand-off markup, also called external markup. A major mode written for use in the field of digital humanities and the manual annotation of training data for named-entity recognition.")
+  "Create stand-off markup, also called external markup.")


### PR DESCRIPTION
The package description text is show directly in the Emacs package menu, and should therefore be very short and concise. The `Commentary` section of the main `.el` file is a good place to include a longer text -- this will be displayed when a user types `?` in the package menu, and on the MELPA package page.
